### PR TITLE
Fix Tokens producing invalid JSON in some cases

### DIFF
--- a/modules/tokens.cpp
+++ b/modules/tokens.cpp
@@ -32,12 +32,10 @@ void Tokens::printJSON(std::ostream & file_out){
         if(i != tokens_found.size() - 1){
             file_out << ", ";
         }
-        else{
-            file_out << " ]," << std::endl;
-        }
     } 
+    file_out << " \t]," << std::endl;
     file_out << "\t\"num_found\": " << tokensfound << "," << std::endl;
-    file_out << "\t\"partial\": " << partial_str << "," << std::endl;
+    file_out << "\t\"partial\": " << partial_str << std::endl;
     file_out << "}" << std::endl;
     return;
 }


### PR DESCRIPTION
In some cases (such as for hw02 from last semester for cutler for cout/cerr), this file will produce an invalid JSON as there are no actual tokens found meaning the trailing "]" would never be printed.

Additionally, remove the trailing comma so you don't have to do that in the client code.